### PR TITLE
Provide error conversion helpers and aggregate errors to ease piping

### DIFF
--- a/rust-lcm-codec/src/error.rs
+++ b/rust-lcm-codec/src/error.rs
@@ -1,0 +1,174 @@
+//! Errors and their conversions relevant to the LCM
+//! codec and the generated code which uses it.
+
+/// Catch-all error for anything that can go wrong encoding
+/// or decoding an LCM message.
+#[derive(Debug, PartialEq)]
+pub enum CodecError<RE, WE> {
+    /// Error decoding (reading) an LCM message
+    DecodeError(DecodeError<RE>),
+    /// Error encoding (writing) an LCM message
+    EncodeError(EncodeError<WE>),
+}
+
+impl<RE, WE> From<DecodeError<RE>> for CodecError<RE, WE> {
+    #[inline]
+    fn from(e: DecodeError<RE>) -> Self {
+        CodecError::DecodeError(e)
+    }
+}
+
+impl<RE, WE> From<DecodeFingerprintError<RE>> for CodecError<RE, WE> {
+    #[inline]
+    fn from(e: DecodeFingerprintError<RE>) -> Self {
+        CodecError::DecodeError(DecodeError::DecodeFingerprintError(e))
+    }
+}
+
+impl<RE, WE> From<DecodeValueError<RE>> for CodecError<RE, WE> {
+    #[inline]
+    fn from(e: DecodeValueError<RE>) -> Self {
+        CodecError::DecodeError(DecodeError::DecodeValueError(e))
+    }
+}
+
+impl<RE, WE> From<EncodeError<WE>> for CodecError<RE, WE> {
+    #[inline]
+    fn from(e: EncodeError<WE>) -> Self {
+        CodecError::EncodeError(e)
+    }
+}
+
+impl<RE, WE> From<EncodeFingerprintError<WE>> for CodecError<RE, WE> {
+    #[inline]
+    fn from(e: EncodeFingerprintError<WE>) -> Self {
+        CodecError::EncodeError(EncodeError::EncodeFingerprintError(e))
+    }
+}
+
+impl<RE, WE> From<EncodeValueError<WE>> for CodecError<RE, WE> {
+    #[inline]
+    fn from(e: EncodeValueError<WE>) -> Self {
+        CodecError::EncodeError(EncodeError::EncodeValueError(e))
+    }
+}
+
+/// The errors that can occur when decoding an LCM message.
+#[derive(Debug, PartialEq)]
+pub enum DecodeError<E> {
+    /// Error decoding fingerprint prior to message body
+    DecodeFingerprintError(DecodeFingerprintError<E>),
+    /// Error decoding a value in the message body
+    DecodeValueError(DecodeValueError<E>),
+}
+
+impl<E> From<DecodeFingerprintError<E>> for DecodeError<E> {
+    #[inline]
+    fn from(e: DecodeFingerprintError<E>) -> Self {
+        DecodeError::DecodeFingerprintError(e)
+    }
+}
+
+impl<E> From<DecodeValueError<E>> for DecodeError<E> {
+    #[inline]
+    fn from(e: DecodeValueError<E>) -> Self {
+        DecodeError::DecodeValueError(e)
+    }
+}
+/// The errors that can occur when decoding the LCM type hash / fingerprint
+/// for a message.
+#[derive(Debug, PartialEq)]
+pub enum DecodeFingerprintError<E> {
+    /// The fingerprint value found did not match the expected value for the
+    /// message type of interest.
+    InvalidFingerprint(u64),
+    /// The underlying StreamingReader encountered an error.
+    ReaderError(E),
+}
+
+impl<E> From<E> for DecodeFingerprintError<E> {
+    #[inline]
+    fn from(e: E) -> Self {
+        DecodeFingerprintError::ReaderError(e)
+    }
+}
+
+/// The errors that can occur when decoding a value in the body
+/// of an LCM message.
+#[derive(Debug, PartialEq)]
+pub enum DecodeValueError<E> {
+    /// The user attempted to read more or fewer items
+    /// out of an array than the array contained.
+    ArrayLengthMismatch(&'static str),
+    /// The value attempted to be decoded was invalid
+    /// in some way.
+    InvalidValue(&'static str),
+    /// The underlying StreamingReader encountered an error.
+    ReaderError(E),
+}
+
+impl<E> From<E> for DecodeValueError<E> {
+    #[inline]
+    fn from(e: E) -> Self {
+        DecodeValueError::ReaderError(e)
+    }
+}
+
+/// The errors that can occur when encoding an LCM message.
+#[derive(Debug, PartialEq)]
+pub enum EncodeError<E> {
+    /// Error encoding fingerprint prior to message body
+    EncodeFingerprintError(EncodeFingerprintError<E>),
+    /// Error encoding a value in the message body
+    EncodeValueError(EncodeValueError<E>),
+}
+
+impl<E> From<EncodeFingerprintError<E>> for EncodeError<E> {
+    #[inline]
+    fn from(e: EncodeFingerprintError<E>) -> Self {
+        EncodeError::EncodeFingerprintError(e)
+    }
+}
+
+impl<E> From<EncodeValueError<E>> for EncodeError<E> {
+    #[inline]
+    fn from(e: EncodeValueError<E>) -> Self {
+        EncodeError::EncodeValueError(e)
+    }
+}
+
+/// The errors that can occur when encoding the LCM type hash / fingerprint
+/// for a message.
+#[derive(Debug, PartialEq)]
+pub enum EncodeFingerprintError<E> {
+    /// The underlying StreamingWriter encountered an error.
+    WriterError(E),
+}
+
+impl<E> From<E> for EncodeFingerprintError<E> {
+    #[inline]
+    fn from(e: E) -> Self {
+        EncodeFingerprintError::WriterError(e)
+    }
+}
+
+/// The errors that can occur when encoding a value in the body
+/// of an LCM message.
+#[derive(Debug, PartialEq, Eq)]
+pub enum EncodeValueError<E> {
+    /// The user attempted to write more or fewer items
+    /// into an array than the array contained.
+    ArrayLengthMismatch(&'static str),
+    /// The value attempted to be encoded was invalid
+    /// in some way.
+    InvalidValue(&'static str),
+    /// The underlying StreamingWriter encountered an error.
+    WriterError(E),
+}
+
+impl<E> From<E> for EncodeValueError<E> {
+    #[inline]
+    fn from(e: E) -> Self {
+        EncodeValueError::WriterError(e)
+    }
+}

--- a/rust-lcm-codec/src/lib.rs
+++ b/rust-lcm-codec/src/lib.rs
@@ -2,63 +2,8 @@
 #![no_std]
 #![deny(warnings)]
 #![deny(missing_docs)]
-
-/// The errors that can occur when decoding the LCM type hash / fingerprint
-/// for a message.
-#[derive(Debug)]
-pub enum DecodeFingerprintError<E> {
-    /// The fingerprint value found did not match the expected value for the
-    /// message type of interest.
-    InvalidFingerprint(u64),
-    /// The underlying StreamingReader encountered an error.
-    ReaderError(E),
-}
-
-impl<E> From<E> for DecodeFingerprintError<E> {
-    fn from(e: E) -> Self {
-        DecodeFingerprintError::ReaderError(e)
-    }
-}
-
-/// The errors that can occur when decoding a value in the body
-/// of an LCM message.
-#[derive(Debug)]
-pub enum DecodeValueError<E> {
-    /// The user attempted to read more or fewer items
-    /// out of an array than the array contained.
-    ArrayLengthMismatch(&'static str),
-    /// The value attempted to be decoded was invalid
-    /// in some way.
-    InvalidValue(&'static str),
-    /// The underlying StreamingReader encountered an error.
-    ReaderError(E),
-}
-
-impl<E> From<E> for DecodeValueError<E> {
-    fn from(e: E) -> Self {
-        DecodeValueError::ReaderError(e)
-    }
-}
-
-/// The errors that can occur when encoding a value in the body
-/// of an LCM message.
-#[derive(Debug, PartialEq, Eq)]
-pub enum EncodeValueError<E> {
-    /// The user attempted to write more or fewer items
-    /// into an array than the array contained.
-    ArrayLengthMismatch(&'static str),
-    /// The value attempted to be encoded was invalid
-    /// in some way.
-    InvalidValue(&'static str),
-    /// The underlying StreamingWriter encountered an error.
-    WriterError(E),
-}
-
-impl<E> From<E> for EncodeValueError<E> {
-    fn from(e: E) -> Self {
-        EncodeValueError::WriterError(e)
-    }
-}
+mod error;
+pub use error::*;
 
 /// Reader backend trait
 pub trait StreamingReader {

--- a/rust-lcm-codec/tests/nested.rs
+++ b/rust-lcm-codec/tests/nested.rs
@@ -1,42 +1,10 @@
 extern crate generated;
 extern crate rust_lcm_codec;
 
-use rust_lcm_codec::BufferWriterError;
-
-#[derive(Debug)]
-enum TestError {
-    BufferWriterError(rust_lcm_codec::BufferWriterError),
-    DecodeFingerprintError(
-        rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>,
-    ),
-    DecodeValueError(rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>),
-    EncodeValueError(rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>),
-}
-
-impl From<rust_lcm_codec::BufferWriterError> for TestError {
-    fn from(e: BufferWriterError) -> Self {
-        TestError::BufferWriterError(e)
-    }
-}
-
-impl From<rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>> for TestError {
-    fn from(e: rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>) -> Self {
-        TestError::DecodeFingerprintError(e)
-    }
-}
-
-impl From<rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>> for TestError {
-    fn from(e: rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>) -> Self {
-        TestError::DecodeValueError(e)
-    }
-}
-
-impl From<rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>> for TestError {
-    fn from(e: rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>) -> Self {
-        TestError::EncodeValueError(e)
-    }
-}
-
+type TestError = rust_lcm_codec::CodecError<
+    rust_lcm_codec::BufferReaderError,
+    rust_lcm_codec::BufferWriterError,
+>;
 #[test]
 fn nested_round_trip_happy_path() -> Result<(), TestError> {
     let mut buf = [0u8; 256];

--- a/rust-lcm-codec/tests/nested_list.rs
+++ b/rust-lcm-codec/tests/nested_list.rs
@@ -1,42 +1,10 @@
 extern crate generated;
 extern crate rust_lcm_codec;
 
-use rust_lcm_codec::BufferWriterError;
-
-#[derive(Debug)]
-enum TestError {
-    BufferWriterError(rust_lcm_codec::BufferWriterError),
-    DecodeFingerprintError(
-        rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>,
-    ),
-    DecodeValueError(rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>),
-    EncodeValueError(rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>),
-}
-
-impl From<rust_lcm_codec::BufferWriterError> for TestError {
-    fn from(e: BufferWriterError) -> Self {
-        TestError::BufferWriterError(e)
-    }
-}
-
-impl From<rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>> for TestError {
-    fn from(e: rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>) -> Self {
-        TestError::DecodeFingerprintError(e)
-    }
-}
-
-impl From<rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>> for TestError {
-    fn from(e: rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>) -> Self {
-        TestError::DecodeValueError(e)
-    }
-}
-
-impl From<rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>> for TestError {
-    fn from(e: rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>) -> Self {
-        TestError::EncodeValueError(e)
-    }
-}
-
+type TestError = rust_lcm_codec::CodecError<
+    rust_lcm_codec::BufferReaderError,
+    rust_lcm_codec::BufferWriterError,
+>;
 #[test]
 fn nested_list_round_trip_happy_path() -> Result<(), TestError> {
     #[derive(Default, Debug, PartialEq)]

--- a/rust-lcm-codec/tests/primitives.rs
+++ b/rust-lcm-codec/tests/primitives.rs
@@ -3,39 +3,20 @@ extern crate rust_lcm_codec;
 
 use rust_lcm_codec::BufferWriterError;
 
-#[derive(Debug)]
-enum TestError {
-    BufferWriterError(rust_lcm_codec::BufferWriterError),
-    DecodeFingerprintError(
-        rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>,
-    ),
-    DecodeValueError(rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>),
-}
-
-impl From<rust_lcm_codec::BufferWriterError> for TestError {
-    fn from(e: BufferWriterError) -> Self {
-        TestError::BufferWriterError(e)
-    }
-}
-
-impl From<rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>> for TestError {
-    fn from(e: rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>) -> Self {
-        TestError::DecodeFingerprintError(e)
-    }
-}
-
-impl From<rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>> for TestError {
-    fn from(e: rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>) -> Self {
-        TestError::DecodeValueError(e)
-    }
-}
+type TestError = rust_lcm_codec::CodecError<
+    rust_lcm_codec::BufferReaderError,
+    rust_lcm_codec::BufferWriterError,
+>;
 
 #[test]
 fn not_big_enough_buffer_for_fingerprint() {
     let mut buf = [0u8; 7];
     let mut w = rust_lcm_codec::BufferWriter::new(&mut buf);
     if let Err(e) = generated::primitives::begin_primitives_t_write(&mut w) {
-        assert_eq!(BufferWriterError, e);
+        assert_eq!(
+            rust_lcm_codec::EncodeFingerprintError::WriterError(BufferWriterError),
+            e
+        );
     } else {
         panic!("Expected an error, dagnabit");
     }
@@ -48,7 +29,10 @@ fn not_big_enough_buffer_for_field() {
     let w = generated::primitives::begin_primitives_t_write(&mut buffer_writer)
         .expect("Enough space for fingerprint");
     if let Err(e) = w.write_int8_field(1) {
-        assert_eq!(BufferWriterError, e);
+        assert_eq!(
+            rust_lcm_codec::EncodeValueError::WriterError(BufferWriterError),
+            e
+        );
     } else {
         panic!("Expected an error");
     }

--- a/rust-lcm-codec/tests/single_dimension_list.rs
+++ b/rust-lcm-codec/tests/single_dimension_list.rs
@@ -1,42 +1,10 @@
 extern crate generated;
 extern crate rust_lcm_codec;
 
-use rust_lcm_codec::BufferWriterError;
-
-#[derive(Debug)]
-enum TestError {
-    BufferWriterError(rust_lcm_codec::BufferWriterError),
-    DecodeFingerprintError(
-        rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>,
-    ),
-    DecodeValueError(rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>),
-    EncodeValueError(rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>),
-}
-
-impl From<rust_lcm_codec::BufferWriterError> for TestError {
-    fn from(e: BufferWriterError) -> Self {
-        TestError::BufferWriterError(e)
-    }
-}
-
-impl From<rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>> for TestError {
-    fn from(e: rust_lcm_codec::DecodeFingerprintError<rust_lcm_codec::BufferReaderError>) -> Self {
-        TestError::DecodeFingerprintError(e)
-    }
-}
-
-impl From<rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>> for TestError {
-    fn from(e: rust_lcm_codec::DecodeValueError<rust_lcm_codec::BufferReaderError>) -> Self {
-        TestError::DecodeValueError(e)
-    }
-}
-
-impl From<rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>> for TestError {
-    fn from(e: rust_lcm_codec::EncodeValueError<rust_lcm_codec::BufferWriterError>) -> Self {
-        TestError::EncodeValueError(e)
-    }
-}
-
+type TestError = rust_lcm_codec::CodecError<
+    rust_lcm_codec::BufferReaderError,
+    rust_lcm_codec::BufferWriterError,
+>;
 #[test]
 fn primitive_list_round_trip_happy_path() -> Result<(), TestError> {
     let mut buf = [0u8; 256];

--- a/rust-lcm-codegen/src/lib.rs
+++ b/rust-lcm-codegen/src/lib.rs
@@ -228,7 +228,7 @@ fn emit_struct(s: &parser::Struct, env: &Environment) -> TokenStream {
 
             #[inline(always)]
             pub fn #begin_write<W: rust_lcm_codec::StreamingWriter>(writer: &'_ mut W)
-                    -> Result<#write_ready_type<'_, W>, W::Error> {
+                    -> Result<#write_ready_type<'_, W>, rust_lcm_codec::EncodeFingerprintError<W::Error>> {
                 writer.write_bytes(&#schema_hash.to_be_bytes())?;
 
                 Ok(#write_ready_type {
@@ -555,7 +555,7 @@ fn emit_writer_field_state_transition_primitive(
         let current_iter_count_initialization =
             emit_next_field_current_iter_count_initialization(next_state);
         quote! {
-            pub fn #write_method_ident(self, val: #maybe_ref #rust_field_type) -> Result<#next_type<'a, W>, W::Error> {
+            pub fn #write_method_ident(self, val: #maybe_ref #rust_field_type) -> Result<#next_type<'a, W>, rust_lcm_codec::EncodeValueError<W::Error>> {
                 #write_invocation
                 Ok(#next_type {
                     writer: self.writer,


### PR DESCRIPTION
Reduces boilerplate in tests, improves control over degrees of specificity for end users.