### PR TITLE
Disable optional features on nom to avoid no_std-unfriendly transitive dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-lcm-codec"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["Russell Mull <russell@auxon.io>", "Zack Pierce <zack@auxon.io>"]
 license = "Apache-2.0"

--- a/rust-lcm-codegen/Cargo.toml
+++ b/rust-lcm-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-lcm-codegen"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["Russell Mull <russell@auxon.io>", "Zack Pierce <zack@auxon.io>"]
 license = "Apache-2.0"
@@ -9,6 +9,6 @@ readme = "README.md"
 description = "Generates Rust de/serialization code from LCM type specification"
 
 [dependencies]
-nom = "5"
+nom = { version = "5", default-features = false, features = ["std"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/tests/generated/Cargo.toml
+++ b/tests/generated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generated"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["Russell Mull <russell@auxon.io>", "Zack Pierce <zack@auxon.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This is to avoid having to wait for https://github.com/Alexhuszagh/rust-lexical/pull/44 to land on `lexical-core`, then `rust-lexical` doing a release, then updating `nom` to use the latest version, then waiting for `nom` to release.